### PR TITLE
Detect adding new .result files

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -2140,6 +2140,7 @@ sub process {
 
 	my %commit_log_tags = ();
 	my $has_changelog = 0;
+	my $warned_about_test_result_file = 0;
 	my $has_doc = 0;
 	my $has_test = 0;
 	my $is_test = 0;
@@ -2821,6 +2822,14 @@ sub process {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			ERROR("TABSTOP",
 			      "please, use spaces instead of tabs\n" . $herevet);
+		}
+
+		if (!$warned_about_test_result_file &&
+		     $realfile =~ /^test\/.*\.result$/ &&
+		     $line =~ /^\+/) {
+			$warned_about_test_result_file = 1;
+			ERROR("TEST_RESULT_FILE",
+			      "Please avoid tests with .result files\n");
 		}
 
 # check we are in a valid C source file if not then ignore this hunk

--- a/doc/checkpatch.rst
+++ b/doc/checkpatch.rst
@@ -774,6 +774,11 @@ Others
   **PRINTF_0XDECIMAL**
     Prefixing 0x with decimal output is defective and should be corrected.
 
+  **TEST_RESULT_FILE**
+    For regression tests, there are .result files. Tests with .result files
+    should be avoided. It is recommended to use Luatest or TAP for Tarantool
+    regression tests.
+
   **TYPO_SPELLING**
     Some words may have been misspelled.  Consider reviewing them.
 


### PR DESCRIPTION
### Test 1:

```diff
sergeyb@pony:~/sources/MRG/checkpatch$ cat test1.patch 
diff --git a/test/unit/ratelimit.result b/test/unit/ratelimit.result
index 8a755c64d8..8ac46045f3 100644
--- a/test/unit/ratelimit.result
+++ b/test/unit/ratelimit.result
@@ -10,4 +10,5 @@ ok 7 - emitted 1 expected 1
 ok 8 - suppressed 0 expected 0
 ok 9 - emitted 1000 expected 1000
 ok 10 - suppressed 3000 expected 3000
+ok 11 - suppressed 3000 expected 3000
        *** main: done ***
sergeyb@pony:~/sources/MRG/checkpatch$ perl checkpatch.pl test1.patch 
total: 0 errors, 5 lines checked

test1.patch has no obvious style problems and is ready for submission.
```

### Test 2:

```
commit 2508bd8c3c1bdba7f19bcbac2eca9eb8d33ba87c
Author: Sergey Bronnikov <sergeyb@tarantool.org>
Date:   Fri Sep 2 09:59:54 2022 +0300

    test: new unit test with result file
    
    NO_CHANGELOG=internal
    NO_DOC=internal
    NO_TEST=internal

diff --git a/test/unit/ratelimit1.c b/test/unit/ratelimit1.c
new file mode 100644
index 0000000000..ce51bf7c28
--- /dev/null
+++ b/test/unit/ratelimit1.c
@@ -0,0 +1,16 @@
+#include <time.h>
+
+#include "unit.h"
+#include "ratelimit.h"
+
+int
+main()
+{
+	header();
+	plan(10);
+
+	check_plan();
+	footer();
+
+	return 0;
+}
diff --git a/test/unit/ratelimit1.result b/test/unit/ratelimit1.result
new file mode 100644
index 0000000000..eb06d8b98e
--- /dev/null
+++ b/test/unit/ratelimit1.result
@@ -0,0 +1,5 @@
+	*** main ***
+1..10
+ok 1 - emitted 10 expected 10
+ok 2 - suppressed 0 expected 0
+	*** main: done ***
sergeyb@pony:~/sources/MRG/checkpatch$ perl checkpatch.pl test2.patch 
ERROR: Bad function definition - main() should probably be main(void)
#23: FILE: test/unit/ratelimit1.c:7:
+main()

ERROR: Please add doc or NO_DOC=<reason> tag

ERROR: Please add changelog or NO_CHANGELOG=<reason> tag

ERROR: Please avoid tests with .result files

total: 4 errors, 21 lines checked
test2.patch has style problems, please review.

NOTE: If any of the errors are false positives, please file a bug at
      https://github.com/tarantool/checkpatch/issues
```

### Test 3

```diff
commit 55bcf9bba4d23e46fd53f1c507dc1e025998d7ad
Author: Sergey Bronnikov <sergeyb@tarantool.org>
Date:   Fri Sep 2 11:07:34 2022 +0300

    test: remove result file
    
    NO_CHANGELOG=internal
    NO_DOC=internal
    NO_TEST=internal

diff --git a/test/unit/random.result b/test/unit/random.result
deleted file mode 100644
index 43ffcfd6ff..0000000000
--- a/test/unit/random.result
+++ /dev/null
@@ -1,59 +0,0 @@
-1..14
-	*** test_random_in_range ***
-    1..2
-    ok 1 - pseudo random is in range -9223372036854775808 9223372036854775807
-    ok 2 - real random is in range -9223372036854775808 9223372036854775807
-ok 1 - subtests
-    1..2
-    ok 1 - pseudo random is in range -9223372036854775808 -9223372036854775808
-    ok 2 - real random is in range -9223372036854775808 -9223372036854775808
-ok 2 - subtests
-    1..2
-    ok 1 - pseudo random is in range 9223372036854775807 9223372036854775807
-    ok 2 - real random is in range 9223372036854775807 9223372036854775807
-ok 3 - subtests
-    1..2
-    ok 1 - pseudo random is in range -1 -1
-    ok 2 - real random is in range -1 -1
-ok 4 - subtests
-    1..2
-    ok 1 - pseudo random is in range 0 0
-    ok 2 - real random is in range 0 0
-ok 5 - subtests
-    1..2
-    ok 1 - pseudo random is in range 1 1
-    ok 2 - real random is in range 1 1
-ok 6 - subtests
-    1..2
-    ok 1 - pseudo random is in range -9223372036854775807 9223372036854775806
-    ok 2 - real random is in range -9223372036854775807 9223372036854775806
-ok 7 - subtests
-    1..2
-    ok 1 - pseudo random is in range -4611686018427387904 4611686018427387903
-    ok 2 - real random is in range -4611686018427387904 4611686018427387903
-ok 8 - subtests
-    1..2
-    ok 1 - pseudo random is in range -9223372036854775808 -4611686018427387904
-    ok 2 - real random is in range -9223372036854775808 -4611686018427387904
-ok 9 - subtests
-    1..2
-    ok 1 - pseudo random is in range 4611686018427387903 9223372036854775807
-    ok 2 - real random is in range 4611686018427387903 9223372036854775807
-ok 10 - subtests
-    1..2
-    ok 1 - pseudo random is in range -2 -1
-    ok 2 - real random is in range -2 -1
-ok 11 - subtests
-    1..2
-    ok 1 - pseudo random is in range 1 2
-    ok 2 - real random is in range 1 2
-ok 12 - subtests
-    1..2
-    ok 1 - pseudo random is in range -1 1
-    ok 2 - real random is in range -1 1
-ok 13 - subtests
-    1..2
-    ok 1 - pseudo random is in range 0 1
-    ok 2 - real random is in range 0 1
-ok 14 - subtests
-	*** test_random_in_range: done ***
```

```sh
sergeyb@pony:~/sources/MRG/checkpatch$ perl checkpatch.pl test3.patch 
ERROR: Please add doc or NO_DOC=<reason> tag

ERROR: Please add changelog or NO_CHANGELOG=<reason> tag

total: 2 errors, 0 lines checked
test3.patch has style problems, please review.

NOTE: If any of the errors are false positives, please file a bug at
      https://github.com/tarantool/checkpatch/issues
sergeyb@pony:~/sources/MRG/checkpatch$ 
```
