### PR TITLE
spelling: writeable -> writable

### DIFF
--- a/spelling.txt
+++ b/spelling.txt
@@ -2,6 +2,8 @@
 # removed, and various additions have been made as they've been discovered
 # in the kernel source.
 #
+# Tarantool authors added a few common mistakes in this checkpatch fork.
+#
 # License: GPLv2
 #
 # The format of each line is:
@@ -1619,6 +1621,7 @@ withing||within
 wnat||want
 wont||won't
 workarould||workaround
+writeable||writable
 writeing||writing
 writting||writing
 wtih||with


### PR DESCRIPTION
The correct spelling was a surprise for me (shame on me), but I also discovered that it is not uncommon in tarantool code and its commit history.