### PR TITLE
Add getenv to the list of unsafe functions

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -4922,6 +4922,7 @@ sub process {
 		if ($line =~ /\b($Ident)\s*\(/) {
 			my $func = $1;
 			my %func_list = (
+				"getenv"		=> "getenv_safe",
 				"sprintf"		=> "snprintf",
 				"vsprintf"		=> "vsnprintf",
 				"strcpy"		=> "strlcpy",


### PR DESCRIPTION
getenv() is bad: it returns a pointer to the environment, which might be changed by a following call to setenv(), making the value pointed to longer and leading to buffer overflows.

See https://github.com/tarantool/tarantool/pull/7807