### PR TITLE
Create action.yml

### DIFF
--- a/.github/actions/checkpatch/action.yml
+++ b/.github/actions/checkpatch/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: tarantool/checkpatch
         path: 'checkpatch'


### PR DESCRIPTION
Use actions/checkout@v3, running on Node.js 16
Removes the following warning from workflows,
using tarantool/checkpatch:

> Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/checkout@v2