### PR TITLE
Do not treat "acknowledgement" as misspelling

### DIFF
--- a/spelling.txt
+++ b/spelling.txt
@@ -53,7 +53,6 @@ acient||ancient
 acitions||actions
 acitve||active
 acknowldegement||acknowledgment
-acknowledgement||acknowledgment
 ackowledge||acknowledge
 ackowledged||acknowledged
 acording||according


### PR DESCRIPTION
Word "acknowledgement" is a British variant of word "acknowledgment". Since we use British dialect sometimes, we should not treat this word as misspelling.