### PR TITLE
Allow line continuation after multiline comment

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -4385,6 +4385,7 @@ sub process {
 
 		} else {
 			if ($prevline !~ /^..*\\$/ &&
+			    $rawline !~ /^\+\s*\*\/\s*\\$/ &&	# multiline comment
 			    $line !~ /^\+\s*\#.*\\$/ &&		# preprocessor
 			    $line !~ /^\+.*\b(__asm__|asm)\b.*\\$/ &&	# asm
 			    $line =~ /^\+.*\\$/) {


### PR DESCRIPTION
If a multiline comment is written inside of a multiline macro, it's enough to put line continuation symbol at the last line of the comment.