### PR TITLE
Fix multiline commit reference check

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -2541,7 +2541,7 @@ sub process {
 
 			my $input = $line;
 			if ($line =~ /(?:\bcommit\s+[0-9a-f]{5,}|\bcommit\s*$)/i) {
-				for (my $n = 0; $n < 2; $n++) {
+				for (my $n = 0; $n < 3; $n++) {
 					if ($input =~ /\bcommit\s+[0-9a-f]{5,}\s*($balanced_parens)/i) {
 						$orig_desc = $1;
 						$has_parens = 1;


### PR DESCRIPTION
There was a classic mess with magic numbers implementing multiline commit reference check: the script looks for "commit" keyword preceding the commit hash and the commit subject in so-called "balanced parens". The script was assuming that the whole structure fits into a one or maximum two consequtive lines. However, with 40-symbol hash the whole reference can spread through three lines: commit + 40-symbol hash + up to 50-symbol commit message in parens and quotes. The aforementioned case occur when "commit" keyword is the only part found in the first line and the subject is split into two lines, since the commit hash takes 40 symbols of the 72 available per commit message line (see example here[1]). Hence, the magic number is simply incremented allowing to use full-length commit hashes in the reference.

[1]: https://github.com/tarantool/tarantool/pull/8920/commits/aa8bffe