### PR TITLE
Allow different indent after comment for the block end

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -2919,10 +2919,10 @@ sub process {
 			      "code indent shouldn't use spaces if the previous line ends with $what\n" . $herevet);
 		}
 
-# alignment should match the comment on the previous line unless it's the end of a function or struct
+# alignment should match the comment on the previous line unless it's the end of block
 		if ($prevrawline =~ /^.(\s*)(?:\/\*.*| )\*\/\s*$/) {
 			my $ident = length($1);
-			if ($rawline =~ /^\+(\s*)[^\}]/ && length($1) != $ident) {
+			if ($rawline =~ /^\+(\s*)[^}\s]/ && length($1) != $ident) {
 				ERROR("CODE_IDENT",
 				      "code indent should match comment\n" . $hereprev);
 			}


### PR DESCRIPTION
Currently the check fails next sane case. We should allow misindent for the case of block end.

```diff
 		  */
+	} catch (FiberIsCancelled *e) {
```