### PR TITLE
Improve LONG_LINE and SPACING errors for array initializers

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -2871,8 +2871,8 @@ sub process {
 			} elsif ($line =~ /^\+.*\\$/ && $length == $max_line_length + 1) {
 				$msg_type = "";
 			# Comment which is used as a header in array initializer
-			# /* FOO  BAR  BAZ */
-			} elsif ($rawline =~ /^.\s*\/\*[a-zA-Z_\s]+\*\/\s*$/) {
+			# /* FOO  BAR  12  34 */
+			} elsif ($rawline =~ /^.\s*\/\*[0-9a-zA-Z_\s]+\*\/\s*$/) {
 				$msg_type = "";
 
 			# Otherwise set the alternate message types


### PR DESCRIPTION
Ignore the errors for array initializers that contain numbers, e.g.:

```
  static bool my_array[] = {
  /* 01  02  03 */
```