### PR TITLE
Don't treat calls of functions from a scope as declarations

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -370,10 +370,13 @@ if ($terse) {
 
 my $emitted_corrupt = 0;
 
-our $Ident	= qr{
-			(?:::)?(?:[A-Za-z_][A-Za-z\d_]*::)*
+our $IdentNoNs  = qr{
 			[A-Za-z_][A-Za-z\d_]*
 			(?:\s*\#\#\s*[A-Za-z_][A-Za-z\d_]*)*
+		}x;
+our $Ident	= qr{
+			(?:::)?(?:[A-Za-z_][A-Za-z\d_]*::)*
+			$IdentNoNs
 		}x;
 our $Storage	= qr{extern|static};
 our $Attribute	= qr{
@@ -4946,7 +4949,7 @@ sub process {
 # check for function declarations that have arguments without identifier names
 # suppress the check for expressions in function context to avoid FP error for class object definition
 		if (defined $stat && !defined $context_function &&
-		    $stat =~ /^.\s*(?:extern\s+)?$Type\s*(?:$Ident|\(\s*\*\s*$Ident\s*\))\s*\(\s*([^{]+)\s*\)\s*;/s &&
+		    $stat =~ /^.\s*(?:extern\s+)?$Type\s*(?:$IdentNoNs|\(\s*\*\s*$IdentNoNs\s*\))\s*\(\s*([^{]+)\s*\)\s*;/s &&
 		    $1 ne "void") {
 			my $args = trim($1);
 			while ($args =~ m/\s*($Type\s*(?:$Ident|\(\s*\*\s*$Ident?\s*\)\s*$balanced_parens)?)/g) {


### PR DESCRIPTION
In C++ it's illegal to declare function using a syntax involving the scope access (`::`) operator, let's make the checkpatch ignore this pattern when looking for function declarations with nameless args.