### PR TITLE
Allow passing empty last argument to macros

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -3923,7 +3923,7 @@ sub process {
 						ERROR("SPACING",
 						      "space prohibited before that '$op' $at\n" . $hereptr);
 					}
-					if ($ctx !~ /.x[WEC]/ && $cc !~ /^}/) {
+					if ($ctx !~ /.x[WECB]/ && $cc !~ /^}/) {
 						ERROR("SPACING",
 						      "space required after that '$op' $at\n" . $hereptr);
 					}


### PR DESCRIPTION
In C it's posssible to pass empty token sequences to a macro, for example: `F(a, b,,)`, the third and fourth arguments of the F macro invokation are empty token sequences.

Let's make the checkpatch understand having the last macro argument empty (the `,)` sequence). This by the way allows `,]` and `,;` but these are illegal in C anyways.