### PR TITLE
Allow defining template functions in macros

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -2986,7 +2986,7 @@ sub process {
 				ERROR("SPACING",
 				      "space prohibited between 'template' and '<'\n" . $herecurr);
 			}
-			if ($rawline !~ />\s*$/) {
+			if ($rawline !~ />\s*\\?$/) {
 				$in_template_indent = length(expand_tabs($1)) + length('template<');
 			}
 		}


### PR DESCRIPTION
Such structure is used in the memtx tree implementation in order to automatically create iterator advancing wrappers:

```C++
template<bool FAST_OFFSET, bool USE_HINT>                                      \
static int                                                                     \
name(struct iterator *iterator, struct tuple **ret)                            \
{                                                                              \
        do {                                                                   \
                int rc = name##_base<FAST_OFFSET, USE_HINT>(iterator, ret);    \
                if (rc != 0 ||                                                 \
                    iterator->next_internal == exhausted_iterator_next)        \
                        return rc;                                             \
        } while (*ret == NULL);                                                \
        return 0;                                                              \
}                                                                              \
```

But the checkpatch does not recognize the end of template parameter list since it's not folowed by a newline, so it assumes the following lines of the macro are next template parameters (and they're misaligned).

This patch fixes this by making the checkpatch aware that the line a template is defined on can end on a backslash character.