### PR TITLE
Check that patch update dependencies versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,17 @@
+name: Testing
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  test:
+    name: Testing
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run regression tests
+      run: bash ./test.sh

--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -500,6 +500,10 @@ our $custom_tags = qr{(?x:
 	NO_CHANGELOG
 )};
 
+our $custom_tags_no_reason = qr{(?x:
+	NO_DEPS_UPDATE
+)};
+
 our $github_ref = qr{(https?:\/\/)?(www\.)?github\.com\b([-a-zA-Z0-9()@:%_\+.~\#?&\/=]*)};
 our $github_issue_ref = qr{((tarantool\/\S+)?\#[1-9][0-9]*)};
 
@@ -2156,6 +2160,8 @@ sub process {
 	my $new_file = 0;
 	my $has_doc = 0;
 	my $has_test = 0;
+	my $need_deps_update = 0;
+	my $has_deps_update = 0;
 	my $is_test = 0;
 
 	# Pre-scan the patch sanitizing the lines.
@@ -2747,7 +2753,8 @@ sub process {
 			}
 		}
 
-		if ($in_commit_log && $line =~ /^($custom_tags)=/) {
+		if ($in_commit_log && ($line =~ /^($custom_tags)=/ ||
+		    $line =~ /^($custom_tags_no_reason)$/)) {
 			$commit_log_tags{$1} = 1;
 			if ($has_doc) {
 				ERROR("TAG_IN_DOC",
@@ -2766,6 +2773,12 @@ sub process {
 		}
 		if ($realfile =~ /^(?:static-build\/)?test\/.*\//) {
 			$has_test = 1;
+		}
+		if ($realfile =~ /^(?:third_party|cmake|CMakeLists\.txt)\//) {
+			$need_deps_update = 1;
+		}
+		if ($realfile =~ /^extra\/dependencies\.yaml/) {
+			$has_deps_update = 1;
 		}
 
 		$is_test = ($realfile =~ /^(?:test|perf)\//);
@@ -5292,6 +5305,11 @@ sub process {
 		if (!$has_test && !exists($commit_log_tags{'NO_TEST'})) {
 			ERROR("NO_TEST",
 			      "Please add test or NO_TEST=<reason> tag\n");
+		}
+		if ($need_deps_update && !exists($commit_log_tags{'NO_DEPS_UPDATE'}) &&
+		    !$has_deps_update) {
+			ERROR("NO_DEPS_UPDATE",
+			      "Please update extra/dependencies.yaml or add NO_DEPS_UPDATE tag\n");
 		}
 	}
 

--- a/doc/checkpatch.rst
+++ b/doc/checkpatch.rst
@@ -766,6 +766,13 @@ Others
     If the patch doesn't need a test (e.g. it fixes a CI issue), please add
     NO_TEST=<reason> to the commit log.
 
+  **NO_DEPS_UPDATE**
+    The patch updates files that may describe external dependencies of the
+    project.  If it does introduce a new build dependency or updates the version
+    of an existing build dependency, please update extra/dependencies.yaml
+    accordingly, otherwise add NO_DEPS_UPDATE to the commit log to suppress
+    this warning.
+
   **NOT_UNIFIED_DIFF**
     The patch file does not appear to be in unified-diff format.  Please
     regenerate the patch file before sending it to the maintainer.

--- a/patches/NO_DEPS_UPDATE-cmake-bump-libiconv-with-dependencies.yaml.patch
+++ b/patches/NO_DEPS_UPDATE-cmake-bump-libiconv-with-dependencies.yaml.patch
@@ -1,0 +1,47 @@
+From 5a069205996251713a3a87a4f996a9d7df152e71 Mon Sep 17 00:00:00 2001
+Message-ID: <5a069205996251713a3a87a4f996a9d7df152e71.1771339327.git.sergeyb@tarantool.org>
+In-Reply-To: <cover.1771339327.git.sergeyb@tarantool.org>
+References: <cover.1771339327.git.sergeyb@tarantool.org>
+From: Sergey Bronnikov <sergeyb@tarantool.org>
+Date: Tue, 17 Feb 2026 17:40:52 +0300
+Subject: [PATCH luajit 2/3] cmake: bump libiconv with dependencies.yaml
+To: tarantool-patches@dev.tarantool.org, Sergey Kaplun <skaplun@tarantool.org>, Maxim Kokryashkin <m.kokryashkin@tarantool.org>
+
+Fixes #
+Closes #
+Needed for #
+See also #
+
+NO_CHANGELOG=internal
+NO_DOC=internal
+NO_TEST=internal
+---
+ cmake/BuildICONV.cmake  | 2 +-
+ extra/dependencies.yaml | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/BuildICONV.cmake b/cmake/BuildICONV.cmake
+index bd2ae84aeb..64df3b11d4 100644
+--- a/cmake/BuildICONV.cmake
++++ b/cmake/BuildICONV.cmake
+@@ -1,4 +1,4 @@
+-set(ICONV_VERSION 1.18)
++set(ICONV_VERSION 1.19)
+ set(ICONV_HASH d718cd5a59438be666d1575855be72c3)
+ set(ICONV_INSTALL_DIR ${BUNDLED_LIBS_INSTALL_DIR}/iconv-prefix)
+ set(ICONV_INCLUDE_DIR ${ICONV_INSTALL_DIR}/include)
+diff --git a/extra/dependencies.yaml b/extra/dependencies.yaml
+index 5a254120d5..b33ee47f91 100644
+--- a/extra/dependencies.yaml
++++ b/extra/dependencies.yaml
+@@ -11,7 +11,7 @@ dependencies:
+   - libcurl:
+     version: 461ce6c6160b86439ddd74c59541231ec9e8558e (curl-8_10_1-241-g461ce6c61)
+   - libiconv:
+-    version: 1.17
++    version: 1.19
+   - libicu:
+     version: 71.1
+   - libncurses:
+--
+2.43.0

--- a/patches/NO_DEPS_UPDATE-cmake-bump-libiconv-with-tag.patch
+++ b/patches/NO_DEPS_UPDATE-cmake-bump-libiconv-with-tag.patch
@@ -1,0 +1,29 @@
+From 6818e4872af491d7de4e364f183e7e24d8665799 Mon Sep 17 00:00:00 2001
+Message-ID: <6818e4872af491d7de4e364f183e7e24d8665799.1771339327.git.sergeyb@tarantool.org>
+In-Reply-To: <cover.1771339327.git.sergeyb@tarantool.org>
+References: <cover.1771339327.git.sergeyb@tarantool.org>
+From: Sergey Bronnikov <sergeyb@tarantool.org>
+Date: Tue, 17 Feb 2026 17:41:33 +0300
+Subject: [PATCH luajit 3/3] cmake: bump libiconv with tag
+To: tarantool-patches@dev.tarantool.org, Sergey Kaplun <skaplun@tarantool.org>, Maxim Kokryashkin <m.kokryashkin@tarantool.org>
+
+NO_CHANGELOG=internal
+NO_DOC=internal
+NO_TEST=internal
+NO_DEPS_UPDATE
+---
+ cmake/BuildICONV.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/BuildICONV.cmake b/cmake/BuildICONV.cmake
+index 64df3b11d4..fced50beb2 100644
+--- a/cmake/BuildICONV.cmake
++++ b/cmake/BuildICONV.cmake
+@@ -1,4 +1,4 @@
+-set(ICONV_VERSION 1.19)
++set(ICONV_VERSION 1.20)
+ set(ICONV_HASH d718cd5a59438be666d1575855be72c3)
+ set(ICONV_INSTALL_DIR ${BUNDLED_LIBS_INSTALL_DIR}/iconv-prefix)
+ set(ICONV_INCLUDE_DIR ${ICONV_INSTALL_DIR}/include)
+--
+2.43.0

--- a/patches/NO_DEPS_UPDATE-cmake-bump-libiconv-wo-tag.patch
+++ b/patches/NO_DEPS_UPDATE-cmake-bump-libiconv-wo-tag.patch
@@ -1,0 +1,29 @@
+From a94e1cb47943b508e94793570a3b760558cd89c5 Mon Sep 17 00:00:00 2001
+Message-ID: <a94e1cb47943b508e94793570a3b760558cd89c5.1771339327.git.sergeyb@tarantool.org>
+In-Reply-To: <cover.1771339327.git.sergeyb@tarantool.org>
+References: <cover.1771339327.git.sergeyb@tarantool.org>
+From: Sergey Bronnikov <sergeyb@tarantool.org>
+Date: Tue, 17 Feb 2026 17:39:34 +0300
+Subject: [PATCH luajit 1/3] cmake: bump libiconv wo tag
+To: tarantool-patches@dev.tarantool.org, Sergey Kaplun <skaplun@tarantool.org>, Maxim Kokryashkin <m.kokryashkin@tarantool.org>
+
+NO_CHANGELOG=internal
+NO_DOC=internal
+NO_TEST=internal
+---
+ cmake/BuildICONV.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/BuildICONV.cmake b/cmake/BuildICONV.cmake
+index 5a417aabe6..bd2ae84aeb 100644
+--- a/cmake/BuildICONV.cmake
++++ b/cmake/BuildICONV.cmake
+@@ -1,4 +1,4 @@
+-set(ICONV_VERSION 1.17)
++set(ICONV_VERSION 1.18)
+ set(ICONV_HASH d718cd5a59438be666d1575855be72c3)
+ set(ICONV_INSTALL_DIR ${BUNDLED_LIBS_INSTALL_DIR}/iconv-prefix)
+ set(ICONV_INCLUDE_DIR ${ICONV_INSTALL_DIR}/include)
+-- 
+2.43.0
+

--- a/patches/test1.patch
+++ b/patches/test1.patch
@@ -1,0 +1,43 @@
+commit 2508bd8c3c1bdba7f19bcbac2eca9eb8d33ba87c
+Author: Sergey Bronnikov <sergeyb@tarantool.org>
+Date:   Fri Sep 2 09:59:54 2022 +0300
+
+    test: new unit test with result file
+    
+    NO_CHANGELOG=internal
+    NO_DOC=internal
+    NO_TEST=internal
+
+diff --git a/test/unit/ratelimit1.c b/test/unit/ratelimit1.c
+new file mode 100644
+index 0000000000..ce51bf7c28
+--- /dev/null
++++ b/test/unit/ratelimit1.c
+@@ -0,0 +1,16 @@
++#include <time.h>
++
++#include "unit.h"
++#include "ratelimit.h"
++
++int
++main()
++{
++	header();
++	plan(10);
++
++	check_plan();
++	footer();
++
++	return 0;
++}
+diff --git a/test/unit/ratelimit1.result b/test/unit/ratelimit1.result
+new file mode 100644
+index 0000000000..eb06d8b98e
+--- /dev/null
++++ b/test/unit/ratelimit1.result
+@@ -0,0 +1,5 @@
++	*** main ***
++1..10
++ok 1 - emitted 10 expected 10
++ok 2 - suppressed 0 expected 0
++	*** main: done ***

--- a/patches/test2.patch
+++ b/patches/test2.patch
@@ -1,0 +1,75 @@
+commit 55bcf9bba4d23e46fd53f1c507dc1e025998d7ad
+Author: Sergey Bronnikov <sergeyb@tarantool.org>
+Date:   Fri Sep 2 11:07:34 2022 +0300
+
+    test: remove result file
+    
+    NO_CHANGELOG=internal
+    NO_DOC=internal
+    NO_TEST=internal
+
+diff --git a/test/unit/random.result b/test/unit/random.result
+deleted file mode 100644
+index 43ffcfd6ff..0000000000
+--- a/test/unit/random.result
++++ /dev/null
+@@ -1,59 +0,0 @@
+-1..14
+-	*** test_random_in_range ***
+-    1..2
+-    ok 1 - pseudo random is in range -9223372036854775808 9223372036854775807
+-    ok 2 - real random is in range -9223372036854775808 9223372036854775807
+-ok 1 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -9223372036854775808 -9223372036854775808
+-    ok 2 - real random is in range -9223372036854775808 -9223372036854775808
+-ok 2 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range 9223372036854775807 9223372036854775807
+-    ok 2 - real random is in range 9223372036854775807 9223372036854775807
+-ok 3 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -1 -1
+-    ok 2 - real random is in range -1 -1
+-ok 4 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range 0 0
+-    ok 2 - real random is in range 0 0
+-ok 5 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range 1 1
+-    ok 2 - real random is in range 1 1
+-ok 6 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -9223372036854775807 9223372036854775806
+-    ok 2 - real random is in range -9223372036854775807 9223372036854775806
+-ok 7 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -4611686018427387904 4611686018427387903
+-    ok 2 - real random is in range -4611686018427387904 4611686018427387903
+-ok 8 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -9223372036854775808 -4611686018427387904
+-    ok 2 - real random is in range -9223372036854775808 -4611686018427387904
+-ok 9 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range 4611686018427387903 9223372036854775807
+-    ok 2 - real random is in range 4611686018427387903 9223372036854775807
+-ok 10 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -2 -1
+-    ok 2 - real random is in range -2 -1
+-ok 11 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range 1 2
+-    ok 2 - real random is in range 1 2
+-ok 12 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range -1 1
+-    ok 2 - real random is in range -1 1
+-ok 13 - subtests
+-    1..2
+-    ok 1 - pseudo random is in range 0 1
+-    ok 2 - real random is in range 0 1
+-ok 14 - subtests
+-	*** test_random_in_range: done ***

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -u
+
+CHECKPATCH=./checkpatch.pl
+
+suite_status=0
+
+# @number - expected exit code
+# @string - checkpatch.pl options
+run_test() {
+    expected_exit_code=$1
+    checkpatch_opts=$2
+
+    shift
+    cmd="$CHECKPATCH $checkpatch_opts"
+    test_output=$($cmd 2>&1 > /dev/null)
+    rc=$?
+    test_status="NOT OK"
+    if [ "$rc" -eq "$expected_exit_code" ]; then
+        test_status="OK"
+    else
+        suite_status=1
+    fi
+    printf "%8s %s\n" "[$test_status]" "$cmd"
+}
+
+run_test 0 "patches/test1.patch"
+run_test 0 "patches/test2.patch"
+
+exit $suite_status

--- a/test.sh
+++ b/test.sh
@@ -27,5 +27,8 @@ run_test() {
 
 run_test 0 "patches/test1.patch"
 run_test 0 "patches/test2.patch"
+run_test 0 "patches/NO_DEPS_UPDATE-cmake-bump-libiconv-with-dependencies.yaml.patch"
+run_test 0 "patches/NO_DEPS_UPDATE-cmake-bump-libiconv-with-tag.patch"
+run_test 1 "patches/NO_DEPS_UPDATE-cmake-bump-libiconv-wo-tag.patch"
 
 exit $suite_status


### PR DESCRIPTION
To disable the new checks, one can add NO_DEPS tag to the commit message.

Required by:
https://github.com/tarantool/tarantool-ee/pull/1648
https://github.com/tarantool/tarantool/pull/12307